### PR TITLE
Redesign: full custom rebuild (modern tech/dev) + curated projects with private-work support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,14 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# October (generated — context bus / browser MCP)
+.claude/settings.local.json
+.mcp.json
+.codex/config.toml
+.codex/hooks.json
+.opencode/plugins/october-bus.js
+opencode.json
+.cursor/mcp.json
+.cursor/cli.json
+.gemini/settings.json

--- a/.grok/config.toml
+++ b/.grok/config.toml
@@ -1,0 +1,7 @@
+[mcp_servers.october-bus]
+url = "http://127.0.0.1:${OCTOBER_BUS_PORT}/mcp"
+enabled = true
+headers = { "X-October-Canvas" = "${OCTOBER_BUS_CANVAS}", "X-October-Node" = "${OCTOBER_BUS_NODE}" }
+
+[permission]
+allow = ["MCPTool(october-bus__*)"]

--- a/index.html
+++ b/index.html
@@ -3,11 +3,43 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
   <link rel="manifest" href="/manifest.json" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Austin J. Hunt - Artsy Software Engineer</title>
+  <meta name="theme-color" content="#0a0e14" />
+
+  <title>Austin J. Hunt — Software Engineer</title>
+  <meta name="description"
+    content="Austin J. Hunt — software engineer at Splunk building cloud infrastructure, full-stack web, automation, and AI integrations. Also a realistic portrait artist." />
+  <meta name="author" content="Austin J. Hunt" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Austin J. Hunt — Software Engineer" />
+  <meta property="og:description"
+    content="Cloud infrastructure, full-stack web, automation & AI integrations — plus realistic portrait art." />
+  <meta property="og:url" content="https://austinjhunt.com" />
+  <meta property="og:image" content="https://austinjhunt.com/logo512.png" />
+  <meta name="twitter:card" content="summary" />
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet" />
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-J174D8T54K"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-J174D8T54K');
+  </script>
+
+  <!-- AdSense -->
   <script async
     src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3189895467675848"
     crossorigin="anonymous"></script>

--- a/index.html
+++ b/index.html
@@ -26,9 +26,14 @@
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
+  <link rel="preload" as="style"
     href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-    rel="stylesheet" />
+    onload="this.onload=null;this.rel='stylesheet'" />
+  <noscript>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet" />
+  </noscript>
 
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-J174D8T54K"></script>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,36 @@
-import config from '../gitprofile.config';
-import GitProfile from './components/GitProfile';
+import './assets/index.css';
+import { useReveal } from './hooks/useReveal';
+import Nav from './sections/Nav';
+import Hero from './sections/Hero';
+import TechMarquee from './sections/TechMarquee';
+import About from './sections/About';
+import Work from './sections/Work';
+import Experience from './sections/Experience';
+import Stack from './sections/Stack';
+import Services from './sections/Services';
+import Testimonials from './sections/Testimonials';
+import Contact from './sections/Contact';
+import Footer from './sections/Footer';
 
 function App() {
-  return <GitProfile config={config} />;
+  useReveal();
+  return (
+    <div className="min-h-screen bg-bg text-text antialiased">
+      <Nav />
+      <main>
+        <Hero />
+        <TechMarquee />
+        <About />
+        <Work />
+        <Experience />
+        <Stack />
+        <Services />
+        <Testimonials />
+        <Contact />
+      </main>
+      <Footer />
+    </div>
+  );
 }
 
 export default App;

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -2,91 +2,184 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --bg: #0a0e14;
+  --bg-elev: #10151d;
+  --bg-card: #121a24;
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.14);
+  --text: #e6edf3;
+  --muted: #8b98a9;
+  --faint: #5a6675;
+  --accent: #2dd4bf;
+  --accent-bright: #5eead4;
+  --accent-dim: rgba(45, 212, 191, 0.12);
+  --accent-glow: rgba(45, 212, 191, 0.35);
+}
+
 * {
-  scrollbar-width: thin;
+  box-sizing: border-box;
 }
 
-::-webkit-scrollbar-track {
-  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
-  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
-  -moz-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
-}
-
-@media screen and (min-width: 966px) {
-  ::-webkit-scrollbar,
-  .scroller {
-    width: 8px;
-    height: 8px;
-    background-color: #f1f1f1;
-  }
-}
-
-::-webkit-scrollbar-thumb {
-  background-color: #888;
-  border-radius: 10px;
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 5rem;
 }
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+  overflow-x: hidden;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+h1,
+h2,
+h3,
+h4 {
+  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  letter-spacing: -0.02em;
+}
+
+.font-mono {
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas,
     monospace;
 }
 
-.text-base-content-important {
-  color: hsla(var(--bc) / var(--tw-text-opacity)) !important;
+/* ——— Backdrop: faint dev grid + accent aura ——— */
+.bg-grid {
+  background-image:
+    linear-gradient(to right, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 44px 44px;
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 40%, transparent 100%);
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 40%, transparent 100%);
 }
 
-svg {
-  vertical-align: unset;
+/* ——— Selection + scrollbar ——— */
+::selection {
+  background: var(--accent-glow);
+  color: #04120f;
 }
 
-.z-hover {
-  transition: all ease-in-out 0.3s !important;
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #2a3543 transparent;
+}
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-thumb {
+  background-color: #2a3543;
+  border-radius: 10px;
+  border: 2px solid var(--bg);
+}
+::-webkit-scrollbar-thumb:hover {
+  background-color: #384656;
 }
 
-.z-hover:hover,
-.z-hover:focus,
-.z-hover:active {
-  transition: transform 0.3s !important;
-  -ms-transform: scale(1.01) !important;
-  -webkit-transform: scale(1.01) !important;
-  transform: scale(1.01) !important;
+/* ——— Reusable bits ——— */
+.card {
+  background-color: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  transition: border-color 0.25s ease, transform 0.25s ease, background-color 0.25s ease;
+}
+.card-hover:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-3px);
 }
 
-.pb-0-important {
-  padding-bottom: 0 !important;
+.chip {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 10px;
+  white-space: nowrap;
 }
 
-.fade-in {
+.link-underline {
+  background-image: linear-gradient(var(--accent), var(--accent));
+  background-size: 0% 1.5px;
+  background-repeat: no-repeat;
+  background-position: left bottom;
+  transition: background-size 0.3s ease;
+}
+.link-underline:hover {
+  background-size: 100% 1.5px;
+}
+
+.accent-glow {
+  box-shadow: 0 0 0 1px rgba(45, 212, 191, 0.4), 0 0 40px -8px var(--accent-glow);
+}
+
+/* ——— Scroll reveal ——— */
+.reveal {
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 0.6s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
+}
+.reveal.is-visible {
   opacity: 1;
-  animation-name: fadeIn;
-  animation-iteration-count: 1;
-  animation-timing-function: ease-in;
-  animation-duration: 1s;
+  transform: none;
 }
 
-@keyframes fadeIn {
-  0% {
-    opacity: 0;
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
   }
-  100% {
+  .reveal {
     opacity: 1;
+    transform: none;
+    transition: none;
   }
 }
 
-@-webkit-keyframes fadeIn {
+/* ——— Marquee (tech ticker) ——— */
+@keyframes marquee {
   from {
-    opacity: 0;
+    transform: translateX(0);
   }
   to {
+    transform: translateX(-50%);
+  }
+}
+.marquee-track {
+  animation: marquee 40s linear infinite;
+}
+.marquee-mask {
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 8%, #000 92%, transparent);
+  mask-image: linear-gradient(to right, transparent, #000 8%, #000 92%, transparent);
+}
+@media (prefers-reduced-motion: reduce) {
+  .marquee-track {
+    animation: none;
+  }
+}
+
+/* ——— Blinking cursor ——— */
+@keyframes blink {
+  0%,
+  49% {
     opacity: 1;
   }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+.cursor-blink {
+  animation: blink 1.1s step-end infinite;
 }

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -10,7 +10,7 @@
   --border-strong: rgba(255, 255, 255, 0.14);
   --text: #e6edf3;
   --muted: #8b98a9;
-  --faint: #5a6675;
+  --faint: #7c8998;
   --accent: #2dd4bf;
   --accent-bright: #5eead4;
   --accent-dim: rgba(45, 212, 191, 0.12);

--- a/src/data/career.js
+++ b/src/data/career.js
@@ -1,0 +1,78 @@
+export const experience = [
+  {
+    company: 'Splunk',
+    role: 'Software Engineer — Enterprise Cloud Infrastructure',
+    from: 'Jun 2025',
+    to: 'Present',
+    url: 'https://splunk.com',
+    current: true,
+  },
+  {
+    company: 'College of Charleston',
+    role: 'Digital Communications Developer',
+    from: 'Feb 2022',
+    to: 'Jun 2025',
+    url: 'https://charleston.edu',
+  },
+  {
+    company: 'College of Charleston',
+    role: 'Webmaster',
+    from: 'Dec 2019',
+    to: 'Feb 2022',
+    url: 'https://charleston.edu',
+  },
+  {
+    company: 'College of Charleston',
+    role: 'Web Team — Temporary Developer',
+    from: 'May 2019',
+    to: 'Dec 2019',
+    url: 'https://charleston.edu',
+  },
+  {
+    company: 'College of Charleston',
+    role: 'Student Network Engineer',
+    from: 'Oct 2017',
+    to: 'May 2019',
+    url: 'https://charleston.edu',
+  },
+  {
+    company: 'Upwork',
+    role: 'Freelance Developer',
+    from: 'Jun 2023',
+    to: 'Present',
+    url: 'https://upwork.com',
+  },
+  {
+    company: 'Austin Hunt Portraiture',
+    role: 'Freelance Portrait Artist',
+    from: '~2015',
+    to: 'Present',
+    url: 'https://sketchyactivity.com',
+  },
+];
+
+export const education = [
+  {
+    institution: 'Vanderbilt University',
+    detail: 'School of Engineering',
+    degree: 'M.S., Computer Science',
+    note: 'GPA 4.0',
+    from: 'May 2021',
+    to: 'Dec 2022',
+  },
+  {
+    institution: 'College of Charleston',
+    detail: 'Honors College',
+    degree: 'B.S., Computer Science — Summa Cum Laude',
+    note: 'GPA 3.96',
+    from: 'Aug 2015',
+    to: 'May 2019',
+  },
+];
+
+export const certifications = [
+  { name: 'Certified Kubernetes Administrator (CKA)', year: 'Nov 2024', link: '/docs/certs/cka-nov-2024.pdf' },
+  { name: 'Docker Certified Associate (DCA)', year: 'Jan 2021', link: '/docs/certs/dca.pdf' },
+  { name: 'Certified Associate in Python Programming (PCAP)', year: 'May 2020', link: '/docs/certs/pcap.pdf' },
+  { name: 'Certified Entry-Level Python Programmer (PCEP)', year: 'May 2020', link: '/docs/certs/pcep.pdf' },
+];

--- a/src/data/profile.js
+++ b/src/data/profile.js
@@ -1,0 +1,86 @@
+// Core identity + contact. Single source of truth for the hero, nav, and footer.
+export const profile = {
+  name: 'Austin J. Hunt',
+  handle: 'austinjhunt',
+  // Short role line shown in the hero status bar.
+  role: 'Software Engineer',
+  company: { name: 'Splunk', url: 'https://splunk.com' },
+  location: 'Greenville, SC',
+
+  // One-liner tagline (hero).
+  tagline: 'Software engineer by trade, portrait artist by instinct.',
+
+  // Longer positioning paragraph (about section).
+  bio: `I build and operate reliable cloud and web systems — from enterprise
+  infrastructure at Splunk to full-stack products, automation pipelines, and
+  AI integrations. I care about clean code, least-privilege security, and
+  things that actually ship. Outside the terminal I draw realistic portraits,
+  which is where the "artist" half of this shows up.`,
+
+  // Availability flag for the freelance / hire-me callout.
+  openToFreelance: true,
+
+  resume: {
+    url: '/docs/ajh2025resume.pdf',
+    label: 'Résumé',
+  },
+
+  // Extra downloadable credentials (grad school portfolio, degree, etc.).
+  documents: [
+    { label: 'M.S. C.S. Portfolio', url: '/docs/vanderbilt/ms-portfolio.pdf' },
+    { label: 'M.S. C.S. Degree', url: '/docs/vanderbilt/ms-cs-degree.pdf' },
+  ],
+};
+
+// Ordered for the nav / contact rail. `primary: true` surfaces in the hero.
+export const socials = [
+  {
+    label: 'GitHub',
+    handle: '@austinjhunt',
+    href: 'https://github.com/austinjhunt',
+    icon: 'github',
+    primary: true,
+  },
+  {
+    label: 'LinkedIn',
+    handle: 'in/huntaj',
+    href: 'https://www.linkedin.com/in/huntaj',
+    icon: 'linkedin',
+    primary: true,
+  },
+  {
+    label: 'Email',
+    handle: 'austincodescleanly@gmail.com',
+    href: 'mailto:austincodescleanly@gmail.com',
+    icon: 'email',
+    primary: true,
+  },
+  {
+    label: 'Art Portfolio',
+    handle: 'sketchyactivity.com',
+    href: 'https://sketchyactivity.com',
+    icon: 'palette',
+    primary: false,
+  },
+  {
+    label: 'Upwork',
+    handle: 'Freelance profile',
+    href: 'https://www.upwork.com/freelancers/~0140398129a6bb7f8d',
+    icon: 'upwork',
+    primary: false,
+  },
+  {
+    label: 'Blog',
+    handle: 'medium/@austinjhunt',
+    href: 'https://medium.com/@austinjhunt',
+    icon: 'medium',
+    primary: false,
+  },
+  {
+    label: 'Instagram',
+    handle: '@talkingtechwithaustin',
+    href: 'https://instagram.com/talkingtechwithaustin',
+    icon: 'instagram',
+    primary: false,
+  },
+];

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1,0 +1,233 @@
+/**
+ * CURATED PROJECTS — the single source of truth for the Work section.
+ *
+ * Unlike the old site, this does NOT read from the public GitHub API. That means
+ * you control exactly what shows, in what order, and you can showcase PRIVATE /
+ * closed-source work (client apps, employer projects, products) that never
+ * appears on your GitHub profile.
+ *
+ * Schema:
+ *   name        (string)   Display name.
+ *   tagline     (string)   One-line hook shown under the title.
+ *   description (string)   1–3 sentences of detail.
+ *   category    (string)   Used for the filter chips. Keep to the set in CATEGORIES below.
+ *   year        (string)   Year or range, e.g. "2024" or "2023 – present".
+ *   status      (string)   e.g. "Live", "In production", "Research", "Archived".
+ *   visibility  ('public' | 'private')
+ *                          'private' → hides source link, shows a lock badge.
+ *   featured    (boolean)  Featured projects render first, larger.
+ *   tech        (string[]) Stack chips (a curated few reads better than 30).
+ *   highlights  (string[]) Optional impact bullets.
+ *   links       (object)   Any of: live, github, video, caseStudy, doc. Omit what you lack.
+ *   image       (string)   Optional path under /public.
+ *   stars       (number)   Optional GitHub stars, for public repos worth flexing.
+ *
+ * TO ADD A PRIVATE PROJECT: copy an entry, set visibility: 'private', drop the
+ * github link (keep `live` only if there's a public product URL), and you're done.
+ */
+
+export const CATEGORIES = [
+  'All',
+  'AI / ML',
+  'Product',
+  'Automation',
+  'Cloud / Infra',
+  'Web',
+  'Research',
+];
+
+export const projects = [
+  // ——— Private / closed-source work (your most impressive, least public) ———
+  {
+    name: 'Enterprise Cloud Infrastructure',
+    tagline: 'Reliability & tooling for Splunk Cloud at scale',
+    description:
+      'Software engineering on Splunk’s enterprise cloud infrastructure team — building and operating the systems that keep large-scale customer environments healthy. Details are internal; the impact is production-grade reliability.',
+    category: 'Cloud / Infra',
+    year: '2025 – present',
+    status: 'In production',
+    visibility: 'private',
+    featured: true,
+    tech: ['Cloud', 'Distributed Systems', 'Automation', 'Observability'],
+    highlights: [
+      'Enterprise-scale, customer-facing cloud infrastructure',
+      'Focus on reliability, automation, and least-privilege security',
+    ],
+    links: { live: 'https://splunk.com' },
+  },
+  {
+    name: 'Snap-n-Sell',
+    tagline: 'Snap a photo → an AI-written marketplace listing',
+    description:
+      'Subscription mobile app that turns a product photo into a ready-to-post resale listing using AI. Includes Stripe subscriptions, account lifecycle (deletion, data controls), and a privacy-first data model.',
+    category: 'Product',
+    year: '2025',
+    status: 'Live',
+    visibility: 'private',
+    featured: true,
+    tech: ['AI / Vision', 'Mobile', 'Stripe', 'Subscriptions'],
+    highlights: [
+      'Photo-to-listing generation with a defined JSON schema',
+      'Full subscription + privacy/account-deletion flows',
+    ],
+    links: { live: '/snap-n-sell/' },
+  },
+  {
+    name: 'NovaBrains',
+    tagline: 'AI-native digital textbook platform, live at UNCC',
+    description:
+      'Digital textbook platform in active use by students and instructors at UNC Charlotte. AI-assisted authoring for instructors (quiz + content generation) and AI-driven learning tools for students (chat, personalized feedback, code analysis). Built with Dr. Ayman Hajja.',
+    category: 'AI / ML',
+    year: '2023 – present',
+    status: 'Live',
+    visibility: 'private',
+    featured: true,
+    tech: ['Django', 'React', 'AWS', 'Postgres', 'OpenAI API'],
+    highlights: [
+      'In production with real students & instructors at UNCC',
+      'RAG + LLM tooling across authoring and learning',
+    ],
+    links: { live: 'https://novabrains.ai' },
+    image: '/img/projects/novabrains.png',
+  },
+  {
+    name: 'StudyRocket',
+    tagline: 'Generate an AI quiz about anything, instantly',
+    description:
+      'Stripe-integrated web service that generates on-the-fly, AI-backed quizzes from uploaded files, Wikipedia articles, or any topic — built to help people truly understand what interests them, beyond memorization.',
+    category: 'AI / ML',
+    year: '2024',
+    status: 'Live',
+    visibility: 'private',
+    featured: true,
+    tech: ['Django', 'React', 'AWS', 'Stripe', 'OpenAI API'],
+    links: { live: 'https://studyrocket.ai' },
+    image: '/img/projects/studyrocket.png',
+  },
+
+  // ——— Public / open-source ———
+  {
+    name: 'msci_esg',
+    tagline: 'Python package for scraping MSCI ESG ratings',
+    description:
+      'A Selenium-powered Python package that extracts data from the MSCI.com ESG Ratings Corporate Search Tool. My most-starred open-source project.',
+    category: 'Automation',
+    year: '2024',
+    status: 'Maintained',
+    visibility: 'public',
+    featured: true,
+    stars: 29,
+    tech: ['Python', 'Selenium', 'PyPI'],
+    links: { github: 'https://github.com/austinjhunt/msci_esg' },
+  },
+  {
+    name: 'Petri Net WebGME Design Studio',
+    tagline: 'Model & simulate distributed systems as Petri nets',
+    description:
+      'A custom WebGME design studio for modeling and simulating distributed systems as Petri (place/transition) nets, built with JointJS and Node.js.',
+    category: 'Research',
+    year: '2024',
+    status: 'Open source',
+    visibility: 'public',
+    featured: false,
+    stars: 5,
+    tech: ['JavaScript', 'WebGME', 'JointJS', 'Node.js'],
+    links: { github: 'https://github.com/austinjhunt/petrinet-webgme-designstudio' },
+  },
+  {
+    name: 'arXiva',
+    tagline: 'A social, searchable, personalized layer over arXiv',
+    description:
+      'A free research tool that turns arXiv into something social, interactive, and personalized — leveraging ElasticSearch and multiple cloud resources for scale. Built with John D. Cobb.',
+    category: 'AI / ML',
+    year: '2023',
+    status: 'Archived',
+    visibility: 'public',
+    featured: false,
+    tech: ['Django', 'ElasticSearch', 'AWS Lightsail', 'Docker'],
+    links: { live: 'https://arxiva.org', github: 'https://github.com/johndcobb/arxiva' },
+    image: '/img/projects/arxiva.png',
+  },
+  {
+    name: 'py-cascade-cms',
+    tagline: 'Python driver for the Cascade CMS 8 REST API',
+    description:
+      'A Python module for enterprise-scale content management against the Cascade CMS 8 REST API (Hannon Hill) — used to automate content operations across a large higher-ed web presence.',
+    category: 'Automation',
+    year: '2024',
+    status: 'Maintained',
+    visibility: 'public',
+    featured: false,
+    stars: 3,
+    tech: ['Python', 'REST'],
+    links: { github: 'https://github.com/austinjhunt/py-cascade-cms' },
+  },
+  {
+    name: 'Go365 Migrator',
+    tagline: 'Enterprise Google Drive → SharePoint migration',
+    description:
+      'A multithreaded, configurable migration assistant that moves files out of Google Drive into SharePoint. Built for College of Charleston’s enterprise migration after Google enforced new storage quotas.',
+    category: 'Automation',
+    year: '2022',
+    status: 'Delivered',
+    visibility: 'public',
+    featured: false,
+    tech: ['Django', 'MS Graph API', 'Azure AD', 'Google Drive API'],
+    links: {
+      github: 'https://github.com/austinjhunt/go365-migrator',
+      video: 'https://www.youtube.com/watch?v=-CzWWTQKGDY',
+    },
+    image: '/img/projects/go365.png',
+  },
+  {
+    name: 'Spring Boot × Ellucian Ethos',
+    tagline: 'Modernizing ERP integration off legacy ASP.NET',
+    description:
+      'A Java Spring Boot application using the Ellucian Ethos Java SDK to read from and write to the Banner ERP system — a migration away from a legacy, out-of-support ASP.NET integration.',
+    category: 'Cloud / Infra',
+    year: '2025',
+    status: 'Open source',
+    visibility: 'public',
+    featured: false,
+    tech: ['Java', 'Spring Boot', 'Ellucian Ethos', 'Banner ERP'],
+    links: { github: 'https://github.com/austinjhunt/spring-boot-ellucian-ethos' },
+  },
+  {
+    name: 'jerrywestonmize.com',
+    tagline: 'Git-managed WordPress for a freelance client',
+    description:
+      'A highly customized WordPress site for a freelance musician & music teacher, with custom plugins and content managed through Git for safe, reviewable deploys.',
+    category: 'Web',
+    year: '2023 – present',
+    status: 'Live',
+    visibility: 'public',
+    featured: false,
+    tech: ['WordPress', 'PHP', 'Git'],
+    links: { live: 'https://jerrywestonmize.com', github: 'https://github.com/austinjhunt/jerrywestonmize' },
+  },
+];
+
+// Selected academic / research writing worth surfacing separately from software.
+export const research = [
+  {
+    name: 'Analyzing CRYSTALS-Dilithium',
+    tagline: 'A quantum-resistant, lattice-based signature scheme',
+    description:
+      'A contextual analysis of CRYSTALS-Dilithium, one of NIST’s first selected post-quantum digital-signature algorithms — covering its lattice-based security, key compression, and design tradeoffs.',
+    link: '/docs/vanderbilt/crystals-dilithium.pdf',
+  },
+  {
+    name: 'Couchbase Tail-Latency Analysis',
+    tagline: 'Multi-phase benchmarking with automation + YCSB',
+    description:
+      'A two-phase tail-latency analysis of Couchbase Server using a custom automated testing framework and the Yahoo! Cloud Serving Benchmark, across dataset sizes, request distributions, and cluster architectures.',
+    link: '/docs/vanderbilt/couchbase-5287.pdf',
+  },
+  {
+    name: 'Threat Modeling My Online Identity',
+    tagline: 'A CIA-triad model of a personal attack surface',
+    description:
+      'Using the confidentiality/integrity/availability methodology to model threats across personal sites, e-commerce, social, email, and payment-linked accounts — and the controls that mitigate them.',
+    link: '/docs/vanderbilt/threatmodel-online-identity.pdf',
+  },
+];

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -59,18 +59,50 @@ export const projects = [
     name: 'Snap-n-Sell',
     tagline: 'Snap a photo → an AI-written marketplace listing',
     description:
-      'Subscription mobile app that turns a product photo into a ready-to-post resale listing using AI. Includes Stripe subscriptions, account lifecycle (deletion, data controls), and a privacy-first data model.',
+      'Native iOS app (SwiftUI) that turns a photo of any item into a ready-to-post marketplace listing using Google Vertex AI, backed by Firebase. Includes subscriptions and full privacy / account-deletion flows.',
     category: 'Product',
-    year: '2025',
+    year: '2026',
     status: 'Live',
     visibility: 'private',
     featured: true,
-    tech: ['AI / Vision', 'Mobile', 'Stripe', 'Subscriptions'],
+    tech: ['SwiftUI', 'iOS', 'Vertex AI', 'Firebase', 'Subscriptions'],
     highlights: [
-      'Photo-to-listing generation with a defined JSON schema',
-      'Full subscription + privacy/account-deletion flows',
+      'Photo-to-listing generation powered by Vertex AI',
+      'Firebase backend with subscription & account-deletion flows',
     ],
     links: { live: '/snap-n-sell/' },
+  },
+  {
+    name: 'RemoteWorkLog',
+    tagline: 'Remote work logging with SSO + AI feedback',
+    description:
+      'Web app for employees and supervisors to manage remote work-log entries. Azure AD SSO auto-sets the supervisor hierarchy on sign-in, email notifications fire on submission, and an OpenAI integration gives AI feedback on each work-log description.',
+    category: 'Web',
+    year: '2025 – present',
+    status: 'Active',
+    visibility: 'private',
+    featured: true,
+    tech: ['Python', 'Azure AD SSO', 'OpenAI API', 'Email'],
+    highlights: [
+      'Azure AD SSO that auto-builds the supervisor hierarchy on login',
+      'AI feedback on entries via OpenAI completions',
+    ],
+    links: {},
+  },
+  {
+    // Newest private repo — no description on GitHub yet; blurb inferred from the
+    // name. TODO(austin): refine this one-liner + tech when ready.
+    name: 'synthgen-pipeline',
+    tagline: 'Synthetic data generation pipeline',
+    description:
+      'A Python pipeline for generating synthetic data — recent private work in progress.',
+    category: 'AI / ML',
+    year: '2026',
+    status: 'In progress',
+    visibility: 'private',
+    featured: false,
+    tech: ['Python'],
+    links: {},
   },
   {
     name: 'NovaBrains',

--- a/src/data/services.js
+++ b/src/data/services.js
@@ -1,0 +1,65 @@
+export const services = [
+  {
+    title: 'LLM Integrations & RAG Pipelines',
+    summary:
+      'AI integrations for your application and RAG pipelines for chatbots, search, and content summarization — designed to be accurate, testable, and cost-aware.',
+  },
+  {
+    title: 'Frontend Web Development',
+    summary:
+      'Building, debugging, or optimizing a frontend across React, Django, TypeScript, and Sass — with a priority on accessibility, performance, and responsiveness.',
+  },
+  {
+    title: 'Backend Web Development',
+    summary:
+      'APIs and services with Node/Express, Flask, Django/DRF, or PHP/LAMP, plus relational and non-relational database integrations.',
+  },
+  {
+    title: 'Cloud Platform Support',
+    summary:
+      'Building or migrating services on AWS, Azure, or GCP — with least-privilege access, cost control, scalability, and CI/CD pipelines.',
+  },
+  {
+    title: 'WordPress Plugin / Theme Development',
+    summary:
+      'Custom WordPress plugins for specific business needs, or themes that align your site with an existing design system.',
+  },
+];
+
+export const testimonials = [
+  {
+    quote:
+      'Austin was incredibly helpful and patient when working with me. He guided me through any issues I had and was very reliable to work with.',
+    author: 'Luke',
+    context: 'Freelance client, Upwork',
+    date: 'Sep 2024',
+  },
+  {
+    quote:
+      "Austin is incredibly knowledgeable, organized, and thorough. As a freelance musician, I don't have the time to dive into custom web development. He provided all the technical support I needed, including several custom plugins. The site is changing my music-lesson business for the better and I couldn't be happier. I can't recommend him enough!",
+    author: 'J. Weston Mize',
+    context: 'Freelance musician & teacher',
+    date: 'Dec 2023',
+  },
+  {
+    quote:
+      'When you ask Austin for help, he jumps right in. He has created multiple tools for employees, and is always willing to hop on a call to walk people through the process. I liken Austin to a famous rock star — he graciously plays the same song over and over for his adoring audience.',
+    author: 'Anonymous',
+    context: 'CofC Cistern Standard recognition',
+    date: 'Apr 2023',
+  },
+  {
+    quote:
+      "Austin is an asset to the College. He continuously problem-solves with the many Cascade CMS users who have varying degrees of comfort in a system with many constraints. Cascade requires creative solutions and Austin is full of them.",
+    author: 'Anonymous',
+    context: 'CofC Cistern Standard recognition',
+    date: 'Oct 2022',
+  },
+  {
+    quote:
+      'I had a LOT of stuff in my Google Drive and tried a few ways to move it to OneDrive with little success. Austin let me know he had built a migration tool. My ridiculously large amount of data broke the tool multiple times, but he kept working until everything was migrated. I really appreciated it!',
+    author: 'Ashley Pagnotta',
+    context: 'CofC Cistern Standard recognition',
+    date: 'Sep 2022',
+  },
+];

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -1,0 +1,36 @@
+// Grouped, curated stack. Reads far better than a wall of 40 chips.
+export const stack = [
+  {
+    group: 'Languages',
+    items: ['Python', 'JavaScript / TypeScript', 'Java', 'PHP', 'Go', 'Bash', 'PowerShell', 'SQL'],
+  },
+  {
+    group: 'Web & Frameworks',
+    items: ['React', 'Django / DRF', 'Flask', 'Node.js', 'Spring Boot', 'WordPress', 'Tailwind CSS'],
+  },
+  {
+    group: 'Cloud & DevOps',
+    items: ['AWS', 'Azure', 'GCP', 'Docker', 'Kubernetes', 'Ansible', 'GitHub Actions', 'CI/CD'],
+  },
+  {
+    group: 'AI & Data',
+    items: ['LLM / RAG pipelines', 'OpenAI API', 'ElasticSearch', 'MySQL / Postgres', 'GraphQL'],
+  },
+  {
+    group: 'Platforms & Integrations',
+    items: ['MS Graph API', 'Azure AD / SSO', 'Ellucian Ethos', 'SharePoint', 'Cascade CMS'],
+  },
+  {
+    group: 'Practice',
+    items: ['Least-privilege security', 'Automation', 'Systems integration', 'Formal verification'],
+  },
+];
+
+// Short focus line for the hero / about.
+export const focus = ['Cloud infrastructure', 'Full-stack web', 'Automation', 'AI integrations'];
+
+export const learning = [
+  'AWS Solutions Architect',
+  'Deeper Kubernetes internals',
+  'Ellucian Ethos integration API',
+];

--- a/src/hooks/useReveal.js
+++ b/src/hooks/useReveal.js
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+// Adds `.is-visible` to every `.reveal` element as it scrolls into view.
+// One shared observer for the whole page — cheap and Lighthouse-friendly.
+export function useReveal() {
+  useEffect(() => {
+    const els = document.querySelectorAll('.reveal');
+    if (!('IntersectionObserver' in window) || els.length === 0) {
+      els.forEach((el) => el.classList.add('is-visible'));
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            io.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -8% 0px' }
+    );
+    els.forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, []);
+}

--- a/src/sections/About.jsx
+++ b/src/sections/About.jsx
@@ -1,0 +1,66 @@
+import Section from '../ui/Section';
+import Icon from '../ui/icons';
+
+const stats = [
+  { value: '8+', label: 'yrs building software' },
+  { value: 'M.S.', label: 'CS, Vanderbilt (4.0)' },
+  { value: 'CKA', label: 'K8s certified' },
+  { value: '10+', label: 'shipped products' },
+];
+
+export default function About() {
+  return (
+    <Section id="about" index="01" label="About" title="Engineer who happens to draw.">
+      <div className="grid gap-10 lg:grid-cols-[1.4fr_1fr]">
+        <div className="reveal space-y-5 text-lg leading-relaxed text-muted">
+          <p>
+            I build and operate reliable cloud and web systems — currently on{' '}
+            <span className="text-text">Splunk's enterprise cloud infrastructure</span>{' '}
+            team, and previously across higher-ed platforms, startups, and freelance
+            products. My work spans full-stack web, automation pipelines, and AI
+            integrations, always with an eye on clean code, least-privilege security,
+            and things that actually ship.
+          </p>
+          <p>
+            The other half of me is a{' '}
+            <a
+              href="https://sketchyactivity.com"
+              target="_blank"
+              rel="noreferrer"
+              className="text-accent link-underline"
+            >
+              realistic portrait artist
+            </a>
+            . That instinct — obsessing over detail until it feels right — is the same
+            one I bring to systems and interfaces.
+          </p>
+        </div>
+
+        <div className="reveal grid grid-cols-2 gap-4">
+          {stats.map((s) => (
+            <div key={s.label} className="card p-5">
+              <div className="font-display text-3xl font-bold text-accent">{s.value}</div>
+              <div className="mt-1 text-sm text-muted">{s.label}</div>
+            </div>
+          ))}
+          <a
+            href="https://sketchyactivity.com"
+            target="_blank"
+            rel="noreferrer"
+            className="card card-hover col-span-2 flex items-center justify-between p-5"
+          >
+            <div>
+              <div className="font-mono text-xs uppercase tracking-widest text-accent">
+                Side of me
+              </div>
+              <div className="mt-1 font-display text-lg font-semibold text-text">
+                Austin Hunt Portraiture
+              </div>
+            </div>
+            <Icon name="arrow" className="h-5 w-5 text-muted" />
+          </a>
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/src/sections/Contact.jsx
+++ b/src/sections/Contact.jsx
@@ -1,0 +1,59 @@
+import Icon from '../ui/icons';
+import { profile, socials } from '../data/profile';
+
+export default function Contact() {
+  return (
+    <section id="contact" className="relative overflow-hidden py-24 sm:py-32">
+      <div
+        className="pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[360px] w-[640px] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-30 blur-[120px]"
+        style={{ background: 'radial-gradient(circle, rgba(45,212,191,0.3), transparent 70%)' }}
+      />
+      <div className="mx-auto max-w-content px-5 text-center sm:px-8">
+        <div className="reveal">
+          <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-accent">
+            07 — Contact
+          </p>
+          <h2 className="font-display text-3xl font-bold text-text sm:text-5xl">
+            Let's build something.
+          </h2>
+          <p className="mx-auto mt-4 max-w-xl text-lg text-muted">
+            Whether it's a product, a migration, an AI integration, or a website that
+            needs saving — my inbox is open.
+          </p>
+
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+            <a
+              href="mailto:austincodescleanly@gmail.com"
+              className="rounded-full bg-accent px-6 py-3 text-sm font-semibold text-[#04120f] transition-transform hover:-translate-y-0.5"
+            >
+              Email me
+            </a>
+            <a
+              href={profile.resume.url}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded-full border border-line-strong px-6 py-3 text-sm font-semibold text-text transition-colors hover:border-accent hover:text-accent"
+            >
+              Download résumé
+            </a>
+          </div>
+
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-x-6 gap-y-3">
+            {socials.map((s) => (
+              <a
+                key={s.label}
+                href={s.href}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 font-mono text-xs text-muted transition-colors hover:text-accent"
+              >
+                <Icon name={s.icon} className="h-4 w-4" />
+                {s.handle}
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Experience.jsx
+++ b/src/sections/Experience.jsx
@@ -1,0 +1,38 @@
+import Section from '../ui/Section';
+import Icon from '../ui/icons';
+import { experience } from '../data/career';
+
+export default function Experience() {
+  return (
+    <Section id="experience" index="03" label="Experience" title="Where I've worked.">
+      <ol className="relative border-l border-line pl-6 sm:pl-8">
+        {experience.map((e, i) => (
+          <li key={i} className="reveal relative pb-9 last:pb-0">
+            <span
+              className={`absolute -left-[7px] top-1.5 h-3 w-3 rounded-full border-2 border-bg ${
+                e.current ? 'bg-accent accent-glow' : 'bg-faint'
+              }`}
+            />
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+              <div>
+                <h3 className="font-display text-lg font-semibold text-text">{e.role}</h3>
+                <a
+                  href={e.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-sm text-accent link-underline"
+                >
+                  {e.company}
+                  <Icon name="arrow" className="h-3.5 w-3.5" />
+                </a>
+              </div>
+              <span className="font-mono text-xs text-faint">
+                {e.from} — {e.to}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </Section>
+  );
+}

--- a/src/sections/Footer.jsx
+++ b/src/sections/Footer.jsx
@@ -1,0 +1,18 @@
+export default function Footer() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="border-t border-line">
+      <div className="mx-auto flex max-w-content flex-col items-center justify-between gap-3 px-5 py-8 sm:flex-row sm:px-8">
+        <p className="font-mono text-xs text-faint">
+          © {year} Austin J. Hunt · built with React, Vite & Tailwind
+        </p>
+        <a
+          href="#top"
+          className="font-mono text-xs text-muted transition-colors hover:text-accent"
+        >
+          back to top ↑
+        </a>
+      </div>
+    </footer>
+  );
+}

--- a/src/sections/Hero.jsx
+++ b/src/sections/Hero.jsx
@@ -1,0 +1,118 @@
+import { profile, socials } from '../data/profile';
+import { focus } from '../data/skills';
+import Icon from '../ui/icons';
+
+export default function Hero() {
+  const primary = socials.filter((s) => s.primary);
+  return (
+    <section id="top" className="relative overflow-hidden pt-32 pb-16 sm:pt-40">
+      {/* backdrop */}
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-grid" />
+      <div
+        className="pointer-events-none absolute left-1/2 top-0 -z-10 h-[420px] w-[720px] -translate-x-1/2 rounded-full opacity-40 blur-[120px]"
+        style={{ background: 'radial-gradient(circle, rgba(45,212,191,0.25), transparent 70%)' }}
+      />
+
+      <div className="mx-auto grid max-w-content items-center gap-12 px-5 sm:px-8 lg:grid-cols-[1.15fr_0.85fr]">
+        {/* left: copy */}
+        <div className="animate-fade-up">
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-line bg-bg-card px-3 py-1.5 font-mono text-xs text-muted">
+            <span className="relative flex h-2 w-2">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-60" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-accent" />
+            </span>
+            {profile.role} @ {profile.company.name} · {profile.location}
+          </div>
+
+          <h1 className="font-display text-4xl font-bold leading-[1.05] text-text sm:text-6xl">
+            Austin&nbsp;J.&nbsp;Hunt
+          </h1>
+
+          <p className="mt-5 max-w-xl text-lg leading-relaxed text-muted">
+            {profile.tagline} I build reliable cloud and web systems — and draw
+            realistic portraits when I step away from the keyboard.
+          </p>
+
+          {/* focus tags */}
+          <div className="mt-6 flex flex-wrap gap-2">
+            {focus.map((f) => (
+              <span key={f} className="chip">
+                {f}
+              </span>
+            ))}
+          </div>
+
+          {/* CTAs */}
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <a
+              href="#work"
+              className="rounded-full bg-accent px-5 py-2.5 text-sm font-semibold text-[#04120f] transition-transform hover:-translate-y-0.5"
+            >
+              View work
+            </a>
+            <a
+              href="#contact"
+              className="rounded-full border border-line-strong px-5 py-2.5 text-sm font-semibold text-text transition-colors hover:border-accent hover:text-accent"
+            >
+              Get in touch
+            </a>
+            <a
+              href={profile.resume.url}
+              target="_blank"
+              rel="noreferrer"
+              className="group inline-flex items-center gap-1.5 px-2 py-2.5 font-mono text-sm text-muted transition-colors hover:text-text"
+            >
+              <Icon name="doc" className="h-4 w-4" />
+              {profile.resume.label}
+            </a>
+          </div>
+
+          {/* socials */}
+          <div className="mt-8 flex items-center gap-4">
+            {primary.map((s) => (
+              <a
+                key={s.label}
+                href={s.href}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={s.label}
+                className="text-muted transition-colors hover:text-accent"
+              >
+                <Icon name={s.icon} className="h-5 w-5" />
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* right: terminal-framed avatar */}
+        <div className="animate-fade-up justify-self-center [animation-delay:120ms] lg:justify-self-end">
+          <div className="card w-[300px] overflow-hidden sm:w-[340px]">
+            <div className="flex items-center gap-2 border-b border-line px-4 py-3">
+              <span className="h-3 w-3 rounded-full bg-[#ff5f57]" />
+              <span className="h-3 w-3 rounded-full bg-[#febc2e]" />
+              <span className="h-3 w-3 rounded-full bg-[#28c840]" />
+              <span className="ml-2 font-mono text-xs text-faint">austin.svg</span>
+            </div>
+            <div
+              className="relative"
+              style={{ background: 'radial-gradient(circle at 50% 35%, rgba(45,212,191,0.14), transparent 65%)' }}
+            >
+              <img
+                src="/img/profile.svg"
+                alt="Low-poly portrait of Austin Hunt"
+                width="340"
+                height="300"
+                loading="eager"
+                className="mx-auto h-auto w-[78%] py-6"
+              />
+            </div>
+            <div className="border-t border-line px-4 py-3 font-mono text-xs text-muted">
+              <span className="text-accent">const</span> role ={' '}
+              <span className="text-accent-bright">'engineer + artist'</span>;
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Nav.jsx
+++ b/src/sections/Nav.jsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+
+const links = [
+  { href: '#work', label: 'Work' },
+  { href: '#experience', label: 'Experience' },
+  { href: '#stack', label: 'Stack' },
+  { href: '#services', label: 'Hire me' },
+  { href: '#contact', label: 'Contact' },
+];
+
+export default function Nav() {
+  const [scrolled, setScrolled] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 24);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <header
+      className={`fixed inset-x-0 top-0 z-50 transition-all duration-300 ${
+        scrolled
+          ? 'border-b border-line bg-bg/80 backdrop-blur-md'
+          : 'border-b border-transparent'
+      }`}
+    >
+      <nav className="mx-auto flex h-16 max-w-content items-center justify-between px-5 sm:px-8">
+        <a href="#top" className="group flex items-center gap-2 font-mono text-sm font-medium">
+          <span className="text-accent">~/</span>
+          <span className="text-text">austin</span>
+          <span className="text-accent cursor-blink">_</span>
+        </a>
+
+        <ul className="hidden items-center gap-8 md:flex">
+          {links.map((l) => (
+            <li key={l.href}>
+              <a
+                href={l.href}
+                className="font-mono text-sm text-muted transition-colors hover:text-text"
+              >
+                {l.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex items-center gap-3">
+          <a
+            href="/docs/ajh2025resume.pdf"
+            target="_blank"
+            rel="noreferrer"
+            className="hidden rounded-full border border-line-strong px-4 py-1.5 font-mono text-xs text-text transition-colors hover:border-accent hover:text-accent sm:inline-block"
+          >
+            Résumé
+          </a>
+          <button
+            onClick={() => setOpen((o) => !o)}
+            aria-label="Toggle menu"
+            className="flex h-9 w-9 items-center justify-center rounded-md border border-line text-text md:hidden"
+          >
+            <span className="font-mono text-lg leading-none">{open ? '×' : '≡'}</span>
+          </button>
+        </div>
+      </nav>
+
+      {open && (
+        <div className="border-t border-line bg-bg/95 backdrop-blur-md md:hidden">
+          <ul className="mx-auto flex max-w-content flex-col px-5 py-2">
+            {links.map((l) => (
+              <li key={l.href}>
+                <a
+                  href={l.href}
+                  onClick={() => setOpen(false)}
+                  className="block py-3 font-mono text-sm text-muted"
+                >
+                  {l.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/sections/Services.jsx
+++ b/src/sections/Services.jsx
@@ -1,0 +1,38 @@
+import Section from '../ui/Section';
+import { services } from '../data/services';
+
+export default function Services() {
+  return (
+    <Section
+      id="services"
+      index="05"
+      label="Freelance"
+      title="Need a developer? I'd love to help."
+      intro="Available for freelance and contract work. Here's where I can plug in."
+    >
+      <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {services.map((s, i) => (
+          <div key={s.title} className="card card-hover reveal p-6">
+            <div className="mb-3 font-mono text-xs text-faint">
+              {String(i + 1).padStart(2, '0')}
+            </div>
+            <h3 className="font-display text-lg font-semibold text-text">{s.title}</h3>
+            <p className="mt-2 text-sm leading-relaxed text-muted">{s.summary}</p>
+          </div>
+        ))}
+
+        <a
+          href="#contact"
+          className="reveal flex flex-col justify-center rounded-2xl border border-dashed border-line-strong p-6 text-center transition-colors hover:border-accent"
+        >
+          <span className="font-display text-lg font-semibold text-accent">
+            Let's talk →
+          </span>
+          <span className="mt-1 text-sm text-muted">
+            Tell me what you're building.
+          </span>
+        </a>
+      </div>
+    </Section>
+  );
+}

--- a/src/sections/Stack.jsx
+++ b/src/sections/Stack.jsx
@@ -1,0 +1,98 @@
+import Section from '../ui/Section';
+import Icon from '../ui/icons';
+import { stack, learning } from '../data/skills';
+import { education, certifications } from '../data/career';
+
+export default function Stack() {
+  return (
+    <Section
+      id="stack"
+      index="04"
+      label="Stack & credentials"
+      title="Tools, degrees, certs."
+    >
+      {/* stack groups */}
+      <div className="reveal grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {stack.map((g) => (
+          <div key={g.group} className="card p-5">
+            <h3 className="mb-3 font-mono text-xs uppercase tracking-[0.15em] text-accent">
+              {g.group}
+            </h3>
+            <ul className="flex flex-wrap gap-2">
+              {g.items.map((it) => (
+                <li key={it} className="chip">
+                  {it}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      {/* education + certs */}
+      <div className="mt-6 grid gap-5 lg:grid-cols-2">
+        <div className="reveal card p-6">
+          <h3 className="mb-4 font-mono text-xs uppercase tracking-[0.15em] text-accent">
+            Education
+          </h3>
+          <ul className="space-y-4">
+            {education.map((ed) => (
+              <li key={ed.institution} className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="font-display font-semibold text-text">{ed.degree}</div>
+                  <div className="text-sm text-muted">
+                    {ed.institution} · {ed.detail}
+                  </div>
+                </div>
+                <div className="text-right font-mono text-xs text-faint">
+                  <div>{ed.note}</div>
+                  <div>
+                    {ed.from}–{ed.to}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="reveal card p-6">
+          <h3 className="mb-4 font-mono text-xs uppercase tracking-[0.15em] text-accent">
+            Certifications
+          </h3>
+          <ul className="space-y-3">
+            {certifications.map((c) => (
+              <li key={c.name}>
+                <a
+                  href={c.link}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group flex items-center justify-between gap-3"
+                >
+                  <span className="flex items-center gap-2 text-sm text-text">
+                    <Icon name="doc" className="h-4 w-4 flex-none text-faint" />
+                    <span className="link-underline">{c.name}</span>
+                  </span>
+                  <span className="font-mono text-xs text-faint">{c.year}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+          {learning.length > 0 && (
+            <div className="mt-5 border-t border-line pt-4">
+              <div className="mb-2 font-mono text-xs uppercase tracking-[0.15em] text-muted">
+                Currently learning
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {learning.map((l) => (
+                  <span key={l} className="chip">
+                    {l}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/src/sections/TechMarquee.jsx
+++ b/src/sections/TechMarquee.jsx
@@ -1,0 +1,23 @@
+const items = [
+  'Python', 'React', 'AWS', 'Kubernetes', 'Docker', 'Django', 'TypeScript',
+  'Terraform', 'Ansible', 'Java', 'Spring Boot', 'GraphQL', 'PostgreSQL',
+  'GitHub Actions', 'Azure', 'GCP', 'Node.js', 'LLM / RAG', 'Linux',
+];
+
+export default function TechMarquee() {
+  const row = [...items, ...items];
+  return (
+    <div className="border-y border-line bg-bg-elev py-4">
+      <div className="marquee-mask overflow-hidden">
+        <div className="marquee-track flex w-max items-center gap-8">
+          {row.map((t, i) => (
+            <span key={i} className="flex items-center gap-8 font-mono text-sm text-faint">
+              <span className="transition-colors hover:text-accent">{t}</span>
+              <span className="text-accent/40">/</span>
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/sections/Testimonials.jsx
+++ b/src/sections/Testimonials.jsx
@@ -1,0 +1,25 @@
+import Section from '../ui/Section';
+import { testimonials } from '../data/services';
+
+export default function Testimonials() {
+  return (
+    <Section id="testimonials" index="06" label="Testimonials" title="Kind words.">
+      <div className="columns-1 gap-5 md:columns-2 lg:columns-3 [&>*]:mb-5">
+        {testimonials.map((t, i) => (
+          <figure key={i} className="card reveal break-inside-avoid p-6">
+            <span className="font-display text-4xl leading-none text-accent/50">“</span>
+            <blockquote className="mt-1 text-sm leading-relaxed text-muted">
+              {t.quote}
+            </blockquote>
+            <figcaption className="mt-4 border-t border-line pt-3">
+              <div className="font-display text-sm font-semibold text-text">{t.author}</div>
+              <div className="font-mono text-xs text-faint">
+                {t.context} · {t.date}
+              </div>
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+    </Section>
+  );
+}

--- a/src/sections/Work.jsx
+++ b/src/sections/Work.jsx
@@ -1,0 +1,187 @@
+import { useMemo, useState } from 'react';
+import Section from '../ui/Section';
+import Icon from '../ui/icons';
+import { projects, research, CATEGORIES } from '../data/projects';
+
+function StatusDot({ status }) {
+  const live = /live|production/i.test(status);
+  return (
+    <span className="inline-flex items-center gap-1.5 font-mono text-xs text-muted">
+      <span className={`h-1.5 w-1.5 rounded-full ${live ? 'bg-accent' : 'bg-faint'}`} />
+      {status}
+    </span>
+  );
+}
+
+function ProjectLinks({ links = {}, visibility }) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 font-mono text-xs">
+      {links.live && (
+        <a
+          href={links.live}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1.5 text-muted transition-colors hover:text-accent"
+        >
+          <Icon name="external" className="h-3.5 w-3.5" /> Live
+        </a>
+      )}
+      {links.github && visibility !== 'private' && (
+        <a
+          href={links.github}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1.5 text-muted transition-colors hover:text-accent"
+        >
+          <Icon name="github" className="h-3.5 w-3.5" /> Source
+        </a>
+      )}
+      {links.video && (
+        <a
+          href={links.video}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1.5 text-muted transition-colors hover:text-accent"
+        >
+          <Icon name="video" className="h-3.5 w-3.5" /> Demo
+        </a>
+      )}
+      {visibility === 'private' && (
+        <span className="inline-flex items-center gap-1.5 text-faint">
+          <Icon name="lock" className="h-3.5 w-3.5" /> Private source
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ProjectCard({ p, featured }) {
+  return (
+    <article
+      className={`card card-hover reveal flex flex-col p-6 ${
+        featured ? 'sm:p-7' : ''
+      }`}
+    >
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <StatusDot status={p.status} />
+          {p.visibility === 'private' && (
+            <span className="inline-flex items-center gap-1 rounded-full border border-line px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-faint">
+              <Icon name="lock" className="h-3 w-3" /> Private
+            </span>
+          )}
+        </div>
+        <span className="font-mono text-xs text-faint">{p.year}</span>
+      </div>
+
+      <h3 className="font-display text-xl font-semibold text-text">{p.name}</h3>
+      <p className="mt-1 text-sm font-medium text-accent">{p.tagline}</p>
+      <p className="mt-3 flex-1 text-sm leading-relaxed text-muted">{p.description}</p>
+
+      {p.highlights && featured && (
+        <ul className="mt-4 space-y-1.5">
+          {p.highlights.map((h) => (
+            <li key={h} className="flex gap-2 text-sm text-muted">
+              <span className="mt-1.5 h-1 w-1 flex-none rounded-full bg-accent" />
+              {h}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {p.tech.map((t) => (
+          <span key={t} className="chip">
+            {t}
+          </span>
+        ))}
+        {typeof p.stars === 'number' && p.stars > 0 && (
+          <span className="chip text-accent">★ {p.stars}</span>
+        )}
+      </div>
+
+      <div className="mt-5 border-t border-line pt-4">
+        <ProjectLinks links={p.links} visibility={p.visibility} />
+      </div>
+    </article>
+  );
+}
+
+export default function Work() {
+  const [filter, setFilter] = useState('All');
+
+  const visible = useMemo(
+    () => (filter === 'All' ? projects : projects.filter((p) => p.category === filter)),
+    [filter]
+  );
+  const featured = visible.filter((p) => p.featured);
+  const rest = visible.filter((p) => !p.featured);
+
+  return (
+    <Section
+      id="work"
+      index="02"
+      label="Selected work"
+      title="Things I've built."
+      intro="A curated mix of public open source and private product work — because the most impactful things I ship usually aren't on my GitHub."
+    >
+      {/* filters */}
+      <div className="reveal mb-8 flex flex-wrap gap-2">
+        {CATEGORIES.map((c) => (
+          <button
+            key={c}
+            onClick={() => setFilter(c)}
+            className={`rounded-full border px-3.5 py-1.5 font-mono text-xs transition-colors ${
+              filter === c
+                ? 'border-accent bg-accent-dim text-accent'
+                : 'border-line text-muted hover:border-line-strong hover:text-text'
+            }`}
+          >
+            {c}
+          </button>
+        ))}
+      </div>
+
+      {featured.length > 0 && (
+        <div className="mb-6 grid gap-5 md:grid-cols-2">
+          {featured.map((p) => (
+            <ProjectCard key={p.name} p={p} featured />
+          ))}
+        </div>
+      )}
+
+      {rest.length > 0 && (
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {rest.map((p) => (
+            <ProjectCard key={p.name} p={p} />
+          ))}
+        </div>
+      )}
+
+      {/* research */}
+      <div className="reveal mt-14">
+        <h3 className="mb-5 flex items-center gap-3 font-mono text-xs uppercase tracking-[0.2em] text-accent">
+          Research & writing <span className="h-px flex-1 bg-line" />
+        </h3>
+        <div className="grid gap-4 md:grid-cols-3">
+          {research.map((r) => (
+            <a
+              key={r.name}
+              href={r.link}
+              target="_blank"
+              rel="noreferrer"
+              className="card card-hover group flex flex-col p-5"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <h4 className="font-display text-base font-semibold text-text">{r.name}</h4>
+                <Icon name="doc" className="h-4 w-4 flex-none text-faint" />
+              </div>
+              <p className="mt-1 text-xs font-medium text-accent">{r.tagline}</p>
+              <p className="mt-2 text-sm leading-relaxed text-muted">{r.description}</p>
+            </a>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/src/ui/Section.jsx
+++ b/src/ui/Section.jsx
@@ -1,0 +1,27 @@
+// Section shell: consistent width, vertical rhythm, and a mono-labeled heading.
+export default function Section({ id, index, label, title, intro, children, className = '' }) {
+  return (
+    <section id={id} className={`relative py-20 sm:py-28 ${className}`}>
+      <div className="mx-auto w-full max-w-content px-5 sm:px-8">
+        {(label || title) && (
+          <header className="reveal mb-12 max-w-2xl">
+            {label && (
+              <div className="mb-3 flex items-center gap-3 font-mono text-xs text-accent">
+                {index && <span className="text-faint">{index}</span>}
+                <span className="uppercase tracking-[0.2em]">{label}</span>
+                <span className="h-px flex-1 bg-line" />
+              </div>
+            )}
+            {title && (
+              <h2 className="font-display text-3xl font-bold text-text sm:text-4xl">
+                {title}
+              </h2>
+            )}
+            {intro && <p className="mt-4 text-base leading-relaxed text-muted">{intro}</p>}
+          </header>
+        )}
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/ui/icons.jsx
+++ b/src/ui/icons.jsx
@@ -1,0 +1,34 @@
+import {
+  FiGithub,
+  FiLinkedin,
+  FiMail,
+  FiInstagram,
+  FiExternalLink,
+  FiLock,
+  FiArrowUpRight,
+  FiPlayCircle,
+  FiFileText,
+} from 'react-icons/fi';
+import { SiUpwork, SiMedium, SiDribbble } from 'react-icons/si';
+import { FaPalette } from 'react-icons/fa';
+
+const map = {
+  github: FiGithub,
+  linkedin: FiLinkedin,
+  email: FiMail,
+  instagram: FiInstagram,
+  upwork: SiUpwork,
+  medium: SiMedium,
+  palette: FaPalette,
+  dribbble: SiDribbble,
+  external: FiExternalLink,
+  arrow: FiArrowUpRight,
+  lock: FiLock,
+  video: FiPlayCircle,
+  doc: FiFileText,
+};
+
+export default function Icon({ name, className }) {
+  const Cmp = map[name] || FiExternalLink;
+  return <Cmp className={className} aria-hidden="true" />;
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,16 +1,38 @@
-import config from './gitprofile.config';
-
+/** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        bg: 'var(--bg)',
+        'bg-elev': 'var(--bg-elev)',
+        'bg-card': 'var(--bg-card)',
+        line: 'var(--border)',
+        'line-strong': 'var(--border-strong)',
+        text: 'var(--text)',
+        muted: 'var(--muted)',
+        faint: 'var(--faint)',
+        accent: 'var(--accent)',
+        'accent-bright': 'var(--accent-bright)',
+      },
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+        display: ['Space Grotesk', 'Inter', 'sans-serif'],
+        mono: ['JetBrains Mono', 'ui-monospace', 'monospace'],
+      },
+      maxWidth: {
+        content: '1100px',
+      },
+      keyframes: {
+        'fade-up': {
+          '0%': { opacity: '0', transform: 'translateY(16px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        'fade-up': 'fade-up 0.7s cubic-bezier(0.22,1,0.36,1) both',
+      },
+    },
   },
-  plugins: [require('daisyui')],
-  daisyui: {
-    logs: false,
-    themes: [
-      ...config.themeConfig.themes,
-      { procyon: config.themeConfig.customTheme },
-    ],
-  },
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
Full custom rebuild of austinjhunt.com, replacing the stock GitProfile/daisyUI template with a bespoke **modern tech/dev** design (dark canvas, single teal accent, Space Grotesk / Inter / JetBrains Mono, terminal motifs, scroll-reveal).

## Key changes
- **New architecture** — content lives in a clean `src/data/` layer; hand-built sections in `src/sections/`, shared UI in `src/ui/`, reveal hook in `src/hooks/`. Dropped the daisyUI theme system.
- **Curated projects model** (`src/data/projects.js`) — the headline change. No longer driven by the public GitHub API, so **private / closed-source work is a first-class citizen**: `visibility: 'private'` shows a 🔒 badge and hides the source link. Populated with real, current work (Splunk infra, Snap-n-Sell, RemoteWorkLog, synthgen-pipeline, NovaBrains, StudyRocket, msci_esg ⭐29, …) via real repo metadata.
- **Sections**: Hero → tech ticker → About → Work (filterable) → Experience timeline → Stack/Credentials → Hire me → Testimonials → Contact.
- **Perf/a11y**: non-blocking font load + WCAG-AA contrast fix.

## Verification
- Lighthouse (mobile): **Performance 99 · Accessibility 100 · Best Practices 79 · SEO 100** (FCP 1.5s, LCP 1.8s, CLS 0.003, TBT 0ms).
  - Best Practices 79 is solely the existing AdSense + Google Analytics third-party cookies — intentionally left untouched.
- Mobile (412px): clean single-column stacking, no horizontal overflow.
- `npm run build` passes.

## Notes
- Old GitProfile machinery (`src/components/`, `gitprofile.config.js`) is now dead code, left in place (not imported). Can be removed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F84CBvYn8q5bRGN1mfxFUD